### PR TITLE
Increasing buffer sizes from 1024 to 8192.

### DIFF
--- a/src/cgp.c
+++ b/src/cgp.c
@@ -874,7 +874,7 @@ DLL_EXPORT struct chromosome* initialiseChromosomeFromFile(char const *file) {
 
 	char *line, *record;
 	char funcName[FUNCTIONNAMELENGTH];
-	char buffer[1024];
+	char buffer[8192];
 
 	int numInputs, numNodes, numOutputs, arity;
 
@@ -2328,7 +2328,7 @@ DLL_EXPORT struct dataSet *initialiseDataSetFromFile(char const *file) {
 	struct dataSet *data;
 	FILE *fp;
 	char *line, *record;
-	char buffer[1024];
+	char buffer[8192];
 	int lineNum = -1;
 	int col;
 


### PR DESCRIPTION
Datasets with many columns (> 100 in my particular case) could easily span more than 1024 bytes per row in text mode, especially if the floating point values have many decimals. 
This was causing the library to fail with an obscure data access error.
I increased the buffer size from 1k to 8k which should be enough for most cases.